### PR TITLE
`rm` the unicode data file, not its parent directory

### DIFF
--- a/functions/anicode.fish
+++ b/functions/anicode.fish
@@ -48,7 +48,7 @@ function __anicode_install
      if not spin --error /dev/null "curl --create-dirs -fsSo $ANICODE_FILE \
          https://unicode.org/Public/UCD/latest/ucd/UnicodeData.txt"
          printf "An error occured, unicode data could not be downloaded."
-         rm $ANICODE_CACHE
+         rm $ANICODE_FILE
          return 1
      end
      return


### PR DESCRIPTION
I think `rm $ANICODE_CACHE` wouldn't work, since it is a directory. This PR has rm delete the $ANICODE_FILE instead.

But perhaps `rm -r $ANICODE_CACHE` is the more correct way: if so, please say so and I'll update the PR accordingly :)